### PR TITLE
fix: id duplication of controlled widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.7.0
+- Fixed a problem with duplicate ids of controlled widgets within the component
 ## 1.6.1
 - Added a reference to the BuildContext in the navigation event handler
 ## 1.6.0

--- a/lib/src/utils/json_utils.dart
+++ b/lib/src/utils/json_utils.dart
@@ -14,23 +14,37 @@ class JsonUtils {
     final attributes = layout["attributes"] as JSONObject?;
     final refs = List.from(attributes?["refs"] ?? []);
 
+    //generate unique id for controlled widgets to prevent duplicates of ids in controllers registry
+    if (layout["controlled"] == true) {
+      final type = layout["type"];
+      final timestamp = DateTime.now().microsecondsSinceEpoch.toString();
+      final id = type + timestamp;
+      layout["id"] = id;
+    }
+
     for (var ref in refs) {
       final payload = ValueReference.fromJson(ref);
       final value = data[payload.objectKey];
 
-      if (value != null ) {
+      if (value != null) {
         attributes?[payload.attributeKey] = value;
       }
     }
 
     if (layout["child"] != null) {
-      mergeComponentLayoutDescriptionWithExternalData(layout["child"], data);
+      mergeComponentLayoutDescriptionWithExternalData(
+        layout["child"],
+        data,
+      );
     }
 
     if (layout["children"] != null) {
       final children = List.from(layout["children"]);
       for (var element in children) {
-        mergeComponentLayoutDescriptionWithExternalData(element, data);
+        mergeComponentLayoutDescriptionWithExternalData(
+          element,
+          data,
+        );
       }
     }
   }


### PR DESCRIPTION
Fixed a problem with duplicate ids of controlled widgets within the component